### PR TITLE
Resolution of various warning message when run in 1.7 

### DIFF
--- a/swingtix/bookkeeper/account_api.py
+++ b/swingtix/bookkeeper/account_api.py
@@ -151,7 +151,7 @@ class AccountBase(object):
         assert amount >= 0
         return self.post(-amount, debit_account, description, self_memo=credit_memo, other_memo=debit_memo, datetime=datetime)
 
-    @transaction.commit_on_success
+    @transaction.atomic
     def post(self, amount, other_account, description, self_memo="", other_memo="", datetime=None):
         """ Post a transaction of 'amount' against this account and the negative amount against 'other_account'.
 

--- a/swingtix/bookkeeper/models.py
+++ b/swingtix/bookkeeper/models.py
@@ -94,7 +94,8 @@ class Account(models.Model, _AccountApi):
 
     positive_credit = models.BooleanField(
         """credit entries increase the value of this account.  Set to False for
-        Asset & Expense accounts, True for Liability, Revenue and Equity accounts.""")
+        Asset & Expense accounts, True for Liability, Revenue and Equity accounts.""",
+        default=False)
 
     name = models.TextField() #slugish?  Unique?
     description = models.TextField(blank=True)

--- a/swingtix/settings.py
+++ b/swingtix/settings.py
@@ -152,3 +152,5 @@ LOGGING = {
         },
     }
 }
+
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'


### PR DESCRIPTION
WRT Issue #4 

Resolution of 'RemovedInDjango18Warning: commit_on_success
is deprecated in favor of atomic' warning message.

The 'atomic' decorator has been available since 1.5 so
I did nothing fancier than replacing 'commit_on_success'.