### PR TITLE
Add future to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     long_description=open('README.rst').read(),
     zip_safe=False,
     include_package_data=True,
+    install_requires=[
+        'future',
+    ],
     tests_require=[
         'django>=1.5,<1.7',
     ],


### PR DESCRIPTION
When I install bookkeeper and try to run syncdb, I get this error:

    ImportError: No module named 'future'

This pull request adds `future` to the dependencies in setup.py