### PR TITLE
Make account names unique within a bookset

### DIFF
--- a/swingtix/bookkeeper/models.py
+++ b/swingtix/bookkeeper/models.py
@@ -107,6 +107,9 @@ class Account(models.Model, _AccountApi):
     name = models.TextField()  # slugish?  Unique?
     description = models.TextField(blank=True)
 
+    class Meta(object):
+        unique_together = ('bookset', 'name')
+
     #functions needed by _AccountApi
     def _make_ae(self, amount, memo, tx):
         ae = AccountEntry()

--- a/swingtix/bookkeeper/test_model.py
+++ b/swingtix/bookkeeper/test_model.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 from builtins import str
 from builtins import range
 
+from django.db import IntegrityError
 from django.test import TestCase
 
 from .models import BookSet, Account, ThirdParty, Project
@@ -328,7 +329,6 @@ class SimpleTest(TestCase):
             description="Revenue",
             positive_credit=True,
         )
-        revenue.save()
 
         bank=Account.objects.create(
             bookset=book,
@@ -336,7 +336,6 @@ class SimpleTest(TestCase):
             description="Bank Account",
             positive_credit=False
         )
-        bank.save()
 
         ar=Account.objects.create(
             bookset=book,
@@ -344,7 +343,6 @@ class SimpleTest(TestCase):
             description="Accounts Receivable",
             positive_credit=False
         )
-        ar.save()
 
         expense=Account.objects.create(
             bookset=book,
@@ -352,7 +350,6 @@ class SimpleTest(TestCase):
             description="Expenses",
             positive_credit=False
         )
-        expense.save()
 
         e2=book.get_account("expense")
         self.assertEqual(e2, expense)
@@ -559,3 +556,7 @@ class SimpleTest(TestCase):
         self.assertEqual(rev.balance(), Decimal("14.72"))
         self.assertEqual(revA.balance(), Decimal("16.53"))
         self.assertEqual(revB.balance(), Decimal("-1.81"))
+
+    def test_duplicate_accounts(self):
+        with self.assertRaises(IntegrityError):
+            Account.objects.create(bookset=self.book, name="bank")  # already exists


### PR DESCRIPTION
The bookset api uses `.get()` to fetch accounts by name. This implies that account names should be unique within a bookset, as `.get()` will raise an exception if there is more than one result.

This pull request makes this explicit by preventing multiple accounts with the same name in the same bookset.