### PR TITLE
Pass custom kwargs to transaction on post

### DIFF
--- a/swingtix/bookkeeper/models.py
+++ b/swingtix/bookkeeper/models.py
@@ -7,8 +7,8 @@ from .account_api import AccountBase, BookSetBase, ProjectBase
 
 
 class _AccountApi(AccountBase):
-    def _new_transaction(self):
-        return Transaction()
+    def _new_transaction(self, **kwargs):
+        return Transaction(**kwargs)
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
This pull request modifies the `AccountBase._new_transaction` method to accept arbitrary keyword arguments, and updates the `AccountBase.debit`, `AccountBase.credit` and `AccountBase.post` methods to forward these arguments to the `_new_transaction` call.

This is useful when overriding `_new_transaction` to use custom transaction subclasses. My use case is to link transactions to application models using generic foreign keys.